### PR TITLE
Fix #12 loads Moodle config from puppet files befer db install

### DIFF
--- a/puppet/modules/moodle/manifests/install.pp
+++ b/puppet/modules/moodle/manifests/install.pp
@@ -9,12 +9,11 @@ class moodle::install {
   package { ['php5-mysql', 'php5-curl', 'php5-gd', 'php5-xmlrpc', 'php5-intl']:
     ensure => "present"
   }->
-  exec { "install_moodle":
-    command => "/bin/rm -r config.php; /usr/bin/php admin/cli/install.php --wwwroot=\"http://local.moodle.dev\" --dataroot=${moodle::dataroot} --dbname=moodle --dbuser=moodle --dbpass=moodle --fullname=MoodleHat --shortname=HAT --adminuser=admin --adminpass=P4ssw0rd! --non-interactive --agree-license --allow-unstable",
-    creates => "${moodle::docroot}/config.php",
-  }->
   file { "${moodle::docroot}/config.php":
     source => 'puppet:///modules/moodle/config.php',
     group => "www-data",
+  }->
+  exec { "install_moodle":
+    command => "/usr/bin/php admin/cli/install_database.php --fullname=MoodleHat --shortname=HAT --adminuser=admin --adminpass=P4ssw0rd! --agree-license",
   }
 }


### PR DESCRIPTION
Works nicely whether a `config.php` file already exists or not.
